### PR TITLE
Respect LDFLAGS during build

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -47,13 +47,13 @@ endif
 	@if [ "${NETTLE_L}" = "no" ]; then echo "WARNING: ** No nettle library found; rdup-tr has no encryption"; fi
 
 rdup-up: $(OBJ_UP) $(HDR)
-	${GCC} ${OBJ_UP} ${GLIB_LIBS} ${LIBS} -o rdup-up
+	${GCC} ${OBJ_UP} ${GLIB_LIBS} ${LDFLAGS} ${LIBS} -o rdup-up
 
 rdup-tr: $(OBJ_TR) $(HDR)
-	${GCC} ${OBJ_TR} ${GLIB_LIBS} ${LIBS} -o rdup-tr
+	${GCC} ${OBJ_TR} ${GLIB_LIBS} ${LDFLAGS} ${LIBS} -o rdup-tr
 
 rdup:	${OBJ} ${HDR} 
-	${GCC} ${OBJ} ${GLIB_LIBS} ${LIBS} -o rdup
+	${GCC} ${OBJ} ${GLIB_LIBS} ${LDFLAGS} ${LIBS} -o rdup
 
 strip:	
 	strip ${CMD}


### PR DESCRIPTION
LDFLAGS are presently not respected during build, and this commit corrects that.
