### PR TITLE
Remove rdup_entry self-assign.

### DIFF
--- a/rdup-tr.c
+++ b/rdup-tr.c
@@ -235,7 +235,6 @@ stdin2archive(void)
 			signal_abort(sig);
                 }
 
-		rdup_entry = rdup_entry;
 #ifdef HAVE_LIBNETTLE
 		if (opt_crypt_key)
 			rdup_entry = crypt_entry(rdup_entry, trhash);


### PR DESCRIPTION
The compilation on OS X Lion fails due to -Werror -Wself-assign. This commit removes the offending line. However, I'm no C programmer, so I might be missing some reason why that assignment is necessary.

$ cc --version
Apple clang version 4.1 (tags/Apple/clang-421.11.66) (based on LLVM 3.1svn)
Target: x86_64-apple-darwin11.4.2
Thread model: posix
