### PR TITLE
Revert "Enable strip again"

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -38,10 +38,10 @@ INSTALL_DATA=$(INSTALL) -m 644
 	${GCC} ${CFLAGS} ${GLIB_CFLAGS} -c $<
 
 ifeq (${ARCHIVE_L},no)
-all:	rdup rdup-up strip
+all:	rdup rdup-up
 	@echo "WARNING: ** No archive library found; not building rdup-tr"
 else
-all:	rdup rdup-up rdup-tr strip
+all:	rdup rdup-up rdup-tr
 endif
 	@chmod +x ${SH}
 	@if [ "${NETTLE_L}" = "no" ]; then echo "WARNING: ** No nettle library found; rdup-tr has no encryption"; fi


### PR DESCRIPTION
This reverts commit 52acad4b66ff6fb11f09957b73f437038bd081be.

This solves two issues:

1) Build breaks when compiling with multiple jobs (`make -j2` or higher)

2) Building non-stripped binaries is not possible without changing the Makefile, which most people are not comfortable with.

More detail on the last issue: On f.i. Gentoo Linux, you can simple install something by typing `emerge foo`; this creates stripped binaries because the package manger handles that. If you want to debug something, you can type `FEATURES="nostrip" emerge foo`, and you'll have non-stripped binaries. Not with rdup though, because it insists on stripping, not leaving a choice for the end user.
