### PR TITLE
fix deprecation warning with libarchive 3.1.2

### DIFF
--- a/rdup-tr.c
+++ b/rdup-tr.c
@@ -364,7 +364,7 @@ not_s_isreg:
 
 	if (opt_output != O_RDUP) {
 		archive_write_close(archive);
-		archive_write_finish(archive);
+		archive_write_free(archive);
 	}
 	g_free(readbuf);
 	g_free(buf);


### PR DESCRIPTION
when compiling with libarchive 3.1.2 in Arch Linux a deprecation warning for archive_write_finish stopped the compilation
