### PR TITLE
Add prerequisites to strip target

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -55,13 +55,11 @@ rdup-tr: $(OBJ_TR) $(HDR)
 rdup:	${OBJ} ${HDR} 
 	${GCC} ${OBJ} ${GLIB_LIBS} ${LDFLAGS} ${LIBS} -o rdup
 
-ifeq (${ARCHIVE_L},no)
-strip:	
-	strip rdup rdup-up
-else
-strip:	
-	strip rdup rdup-tr rdup-up
+strip:	rdup rdup-up
+ifneq (${ARCHIVE_L},no)
+strip:	drup-tr
 endif
+	strip $^
 
 po:	rdup.pot 
 	( cd po ; $(MAKE) -f GNUmakefile all )


### PR DESCRIPTION
I assume that because of missing prerequisites for the strip target, stripping fails when make is runs several jobs in parallel (-jX).
