### PR TITLE
Fix typo: 'rdup-tr' not 'drup-tr'

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -57,7 +57,7 @@ rdup:	${OBJ} ${HDR}
 
 strip:	rdup rdup-up
 ifneq (${ARCHIVE_L},no)
-strip:	drup-tr
+strip:	rdup-tr
 endif
 	strip $^
 


### PR DESCRIPTION
The `strip` dependency is `rdup-tr` not `drup-tr`.