### PR TITLE
Revert "force dirfd on macos"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,19 +13,10 @@ AC_PROG_MAKE_SET
 
 AM_PATH_GLIB_2_0(2.0.0,,AC_MSG_ERROR([** No glib2-dev library found.]))
 
-# on mac OS this keeps failing, but it does have dirfd, although
-# it is an macro
-case `uname -s` in 
-    Darwin)
-	AC_SUBST(HAVE_DIRFD)
-	;;
-    *)
-	# dirfd
-	AC_CHECK_FUNCS([dirfd])
-	AC_CHECK_MEMBERS([DIR.d_fd],,,  [[#include <dirent.h>]])
-	AC_CHECK_MEMBERS([DIR.dd_fd],,, [[#include <dirent.h>]]) 
-	;;
-esac
+# dirfd stuff
+AC_CHECK_FUNCS([dirfd])
+AC_CHECK_MEMBERS([DIR.d_fd],,,  [[#include <dirent.h>]])
+AC_CHECK_MEMBERS([DIR.dd_fd],,, [[#include <dirent.h>]])
 
 AC_CHECK_HEADERS([getopt.h dirent.h sys/vfs.h sys/statvfs.h sys/sysmacros.h])
 AC_CHECK_HEADERS(sys/param.h sys/mount.h,,,


### PR DESCRIPTION
This reverts commit 57f41c9e52ac588e0370e47281e135114491fa09.

The check now works on OS X, so there's no longer a need for this
commit. In addition, the original commit (at least currently) hasn't
been working, since HAVE_DIRFD is coming up undefined, causing it to be
force disabled.

Closes #25