### PR TITLE
Support compilation under cygwin environment

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@
 * Timur Vafin
 * Alejandro Pulver
 * Richard Kojedzinszky
+* Masen Furer - cygwin testing

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+04 Aug 2017: 1.1.16 Masen Furer <mf@0x26.net>
+  * add windows support with Cygwin
+
 02 Mar 2016: 1.1.15 Miek Gieben <miek@miek.nl>
   * [rdup] Change -P so any arguments are executed with 'sh -c', 
     this removes the 7 option limit (Alexander Neumann)

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -10,6 +10,13 @@ Mandatory:
 
 If libarchive is not found rdup-tr is not built.
 
+Cygwin dependencies:
+* Build:
+  * autoconf,automake,gcc-core,make
+  * libarchive-devel,libglib2.0-devel,libnettle-devel,libpcre-devel
+* Test: dejagnu,mcrypt
+* Run: libarchive13,libglib2.0_0,libnettle4,libpcre1
+
 To build from git:
 
     autoconf && ./configure && make && make install

--- a/README
+++ b/README
@@ -37,6 +37,7 @@ the following
 * Linux
 * Solaris
 * FreeBSD
+* Cygwin
 
 ./configure will try to do the right thing, if you don't have
 specific libraries certain functionality isn't built.

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.57)
-AC_INIT(rdup, 1.1.15, miek@miek.nl, rdup)
+AC_INIT(rdup, 1.1.16, miek@miek.nl, rdup)
 AC_CONFIG_SRCDIR([rdup.c])
 AC_PREFIX_DEFAULT(/usr/local)
 

--- a/rdup-tr.c
+++ b/rdup-tr.c
@@ -30,9 +30,12 @@ gint opt_input = I_RDUP;	/* default intput */
 int sig = 0;
 char *o_fmt[] = { "", "tar", "cpio", "pax", "rdup" };	/* O_NONE, O_TAR, O_CPIO, O_PAX, O_RDUP */
 
+#ifdef __CYGWIN__
+extern int __declspec(dllimport) opterr;
+#else
 extern int opterr;
-
 int opterr = 0;
+#endif
 
 /* common.c */
 struct rdup *entry_dup(struct rdup *f);

--- a/rdup-up.c
+++ b/rdup-up.c
@@ -23,8 +23,12 @@ guint opt_path_strip_len = 0;	/* number of path labels in opt_path_strip */
 guint opt_strip = 0;		/* -s: strippath */
 int sig = 0;
 GSList *hlink_list = NULL;	/* save hardlink for post processing */
+#ifdef __CYGWIN__
+extern int __declspec(dllimport) opterr;
+#else
 extern int opterr;
 int opterr = 0;
+#endif
 
 /* update the directory with the archive */
 static gboolean update(char *path)

--- a/rdup.c
+++ b/rdup.c
@@ -24,8 +24,12 @@ size_t opt_size = 0;		/* only output files smaller then <size> */
 time_t opt_timestamp = 0;	/* timestamp file c|m time */
 
 int sig = 0;
+#ifdef __CYGWIN__
+extern int __declspec(dllimport) opterr;
+#else
 extern int opterr;
 int opterr = 0;
+#endif
 GSList *child = NULL;
 
 #define CORRUPT(x)	{ \


### PR DESCRIPTION
In the past, I've seen you close an issue because you don't use windows, so I understand if you don't want to take this change.

I did a bit of tinkering to get rdup to build and run in a cygwin windows environment and figured I should contribute it back in case anyone else was interested.

rdup has been an indispensable utility for me since 2012 and though I'm working with more windows servers these days, I can't give up the simplicity and ease of unix style backups.

Thanks for your consideration,
Masen Furer

```
MFSEA-W10-02+Administrator@mfsea-w10-02 ~/rdup-cygwin-support
$ autoreconf

MFSEA-W10-02+Administrator@mfsea-w10-02 ~/rdup-cygwin-support
$ ./configure
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.exe
checking for suffix of executables... .exe
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking how to run the C preprocessor... gcc -E
checking for grep that handles long lines and -e... /usr/bin/grep
checking for egrep... /usr/bin/grep -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking minix/config.h usability... no
checking minix/config.h presence... no
checking for minix/config.h... no
checking whether it is safe to define __EXTENSIONS__... yes
checking for gcc... (cached) gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to accept ISO C89... (cached) none needed
checking whether make sets $(MAKE)... yes
checking for pkg-config... /usr/bin/pkg-config
checking for GLIB - version >= 2.0.0... yes (version 2.50.3)
checking for dirfd... yes
checking for DIR.d_fd... no
checking for DIR.dd_fd... no
checking getopt.h usability... yes
checking getopt.h presence... yes
checking for getopt.h... yes
checking dirent.h usability... yes
checking dirent.h presence... yes
checking for dirent.h... yes
checking sys/vfs.h usability... yes
checking sys/vfs.h presence... yes
checking for sys/vfs.h... yes
checking sys/statvfs.h usability... yes
checking sys/statvfs.h presence... yes
checking for sys/statvfs.h... yes
checking sys/sysmacros.h usability... yes
checking sys/sysmacros.h presence... yes
checking for sys/sysmacros.h... yes
checking for sys/param.h... yes
checking for sys/mount.h... yes
checking for archive_entry_copy_symlink in -larchive... yes
checking pcre.h usability... yes
checking pcre.h presence... yes
checking for pcre.h... yes
checking for pcre_compile in -lpcre... yes
checking nettle/aes.h usability... yes
checking nettle/aes.h presence... yes
checking for nettle/aes.h... yes
checking for nettle_aes_encrypt in -lnettle... yes
configure: creating ./config.status
config.status: creating GNUmakefile
config.status: creating po/GNUmakefile
config.status: creating rdup.h
config.status: creating rdup-tr.h
config.status: creating rdup-up.h
config.status: creating doc/rdup.1
config.status: creating doc/rdup-tr.1
config.status: creating doc/rdup-up.1
config.status: creating config.h

MFSEA-W10-02+Administrator@mfsea-w10-02 ~/rdup-cygwin-support
$ make
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c crawler.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c rdup.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c gfunc.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c getdelim.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c signal.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c usage.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c sha1.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c regexp.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c abspath.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c link.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c reverse.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c protocol.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c msg.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c common.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c names.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c child.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c chown.c
gcc crawler.o rdup.o gfunc.o getdelim.o signal.o usage.o sha1.o regexp.o abspath.o link.o reverse.o protocol.o msg.o common.o names.o child.o chown.o -lglib-2.0 -lintl  -lnettle -lpcre -larchive  -lpcre -o rdup
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c rdup-up.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c entry.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c usage-up.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c rm.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c fs-up.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c mkpath.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c dir.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c strippath.c
gcc rdup-up.o entry.o usage-up.o signal.o link.o getdelim.o abspath.o rm.o fs-up.o mkpath.o protocol.o msg.o dir.o common.o strippath.o names.o chown.o -lglib-2.0 -lintl  -lnettle -lpcre -larchive  -lpcre -o rdup-up
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c rdup-tr.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c usage-tr.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c crypt.c
gcc -Wall -W -Werror -g -O2  -DHAVE_CONFIG_H -DLOCALEROOTDIR=\"/usr/local/share/locale\" -D_FILE_OFFSET_BITS=64 -D_LARGE_FILES -Os -Wpointer-arith -Wstrict-prototypes  -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -c base64.c
gcc rdup-tr.o signal.o getdelim.o usage-tr.o entry.o link.o protocol.o msg.o crypt.o base64.o common.o -lglib-2.0 -lintl  -lnettle -lpcre -larchive  -lpcre -o rdup-tr

MFSEA-W10-02+Administrator@mfsea-w10-02 ~/rdup-cygwin-support
$ make install
mkdir -p /usr/local/share/man/man1
for i in rdup rdup-tr rdup-up; do ./install-sh -c $i /usr/local/bin/$i ; done
for i in rdup-simple; do ./install-sh -c $i /usr/local/bin/$i ; done
for i in doc/rdup.1 doc/rdup-tr.1 doc/rdup-up.1 doc/rdup-simple.1; do [ -f $i ] &&  ./install-sh -c -m 644 $i /usr/local/share/man/man1/`basename $i` ; done; exit 0
for i in doc/rdup-backups.7; do [ -f $i ] &&  ./install-sh -c -m 644 $i /usr/local/share/man/man7/`basename $i` ; done; exit 0
make -C po install
make[1]: Entering directory '/home/Administrator/rdup-cygwin-support/po'
for i in $(cat LINGUAS); do rm -rf $i && mkdir $i; \
    cp $i.gmo $i/rdup.mo; done
for i in $(cat LINGUAS); do \
        mkdir -p //usr/local/share/locale/$i/LC_MESSAGES; \
        cp $i/rdup.mo //usr/local/share/locale/$i/LC_MESSAGES/rdup.mo; \
done
make[1]: Leaving directory '/home/Administrator/rdup-cygwin-support/po'

MFSEA-W10-02+Administrator@mfsea-w10-02 ~/rdup-cygwin-support
$ echo $(which rdup) $(which rdup-up) $(which rdup-tr)
/usr/local/bin/rdup /usr/local/bin/rdup-up /usr/local/bin/rdup-tr

MFSEA-W10-02+Administrator@mfsea-w10-02 ~/rdup-cygwin-support
$ make check
runtest
WARNING: Couldn't find the global config file.
Test Run By MFSEA-W10-02+Administrator on Fri Aug  4 03:39:29 2017
Native configuration is x86_64-unknown-cygwin

                === rdup tests ===

Schedule of variations:
    unix

Running target unix
Using /usr/share/dejagnu/baseboards/unix.exp as board description file for target.
Using /usr/share/dejagnu/config/unix.exp as generic interface file for target.
WARNING: Couldn't find tool config file for unix, using default.
Running ./testsuite/rdup/rdup.a-flag.exp ...
Running ./testsuite/rdup/rdup.chmod.exp ...
Running ./testsuite/rdup/rdup.dir.exp ...
Running ./testsuite/rdup/rdup.full.exp ...
Running ./testsuite/rdup/rdup.fuzzing1.exp ...
Running ./testsuite/rdup/rdup.fuzzing2.exp ...
Running ./testsuite/rdup/rdup.hardlink-strip.exp ...
Running ./testsuite/rdup/rdup.hardlink-strip2.exp ...
Running ./testsuite/rdup/rdup.hardlink.exp ...
Running ./testsuite/rdup/rdup.incr-readonly-dir.exp ...
Running ./testsuite/rdup/rdup.incr-rm-file.exp ...
Running ./testsuite/rdup/rdup.incr-rm-link.exp ...
Running ./testsuite/rdup/rdup.incr.exp ...
Running ./testsuite/rdup/rdup.ln-up.exp ...
Running ./testsuite/rdup/rdup.ln.exp ...
Running ./testsuite/rdup/rdup.m-flag.exp ...
Running ./testsuite/rdup/rdup.match.exp ...
Running ./testsuite/rdup/rdup.mvdir.exp ...
Running ./testsuite/rdup/rdup.newdir.exp ...
Running ./testsuite/rdup/rdup.nobackup-symlink.exp ...
Running ./testsuite/rdup/rdup.nobackup1.exp ...
Running ./testsuite/rdup/rdup.nobackup2.exp ...
Running ./testsuite/rdup/rdup.nonwritedir.exp ...
Running ./testsuite/rdup/rdup.nonzero.exp ...
Running ./testsuite/rdup/rdup.pipeline.exp ...
Running ./testsuite/rdup/rdup.r-flag.exp ...
Running ./testsuite/rdup/rdup.rdup-hash.exp ...
Running ./testsuite/rdup/rdup.rdup-tr-crypt.exp ...
Running ./testsuite/rdup/rdup.rdup-tr-decrypt.exp ...
Running ./testsuite/rdup/rdup.rdup-tr-encrypt.exp ...
Running ./testsuite/rdup/rdup.rdup-up-n.exp ...
Running ./testsuite/rdup/rdup.rdup-up-s.exp ...
Running ./testsuite/rdup/rdup.rdup-up-t-with-file.exp ...
Running ./testsuite/rdup/rdup.rdup-up.exp ...
Running ./testsuite/rdup/rdup.root-symlink.exp ...
Running ./testsuite/rdup/rdup.run-tr.exp ...
Running ./testsuite/rdup/rdup.run-up.exp ...
Running ./testsuite/rdup/rdup.run.exp ...
Running ./testsuite/rdup/rdup.s-flag.exp ...
Running ./testsuite/rdup/rdup.simple.exp ...
Running ./testsuite/rdup/rdup.simple2.exp ...
Running ./testsuite/rdup/rdup.simple3.exp ...

                === rdup Summary ===

# of expected passes            41

MFSEA-W10-02+Administrator@mfsea-w10-02 ~/rdup-cygwin-support
$ uname -a
CYGWIN_NT-10.0 mfsea-w10-02 2.8.2(0.313/5/3) 2017-07-12 10:58 x86_64 Cygwin
```