### PR TITLE
Potentially dangerours write to freed pointer

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -61,10 +61,9 @@ gchar *dir_parent(gchar * p)
 	copy = g_strdup(p);
 	n = strrchr(copy, '/');
 	if (n) {
-		*(n + 1) = '\0';
+		*n = '\0';
 		p2 = g_strdup(copy);
 		g_free(copy);
-		*n = '/';
 		return p2;
 	}
 	return NULL;


### PR DESCRIPTION
n was referenced after copy was freed.

In addition, nowhere dir_parent() results are used the trailing / makes
sense, so don't include it.