### PR TITLE
rdup-up: handle reversed (-R) rdup dumps

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -69,3 +69,41 @@ gchar *dir_parent(gchar * p)
 	}
 	return NULL;
 }
+
+/**
+  * Make sure a path exists
+  */
+
+void dir_mkpath(gchar *p)
+{
+	gchar *parent;
+
+        parent = dir_parent(p);
+
+	if (parent && (parent[0] == 0)) {
+		msgd(__func__, __LINE__, _("Reached / while trying to create path, bailing out."));
+		g_free(parent);
+		return;
+	}
+
+#if DEBUG
+	msgd(__func__, __LINE__, _("Creating skeleton directory `%s\'"), parent);
+#endif
+
+	struct stat *st = g_malloc(sizeof(struct stat));
+
+	if (stat(parent, st) != 0) {
+		/* Directory does not exist. EEXIST for race condition */
+		if (mkdir(parent, 0700) != 0 && errno != EEXIST) {
+			dir_mkpath(parent);
+			if (mkdir(parent, 0700) != 0 && errno != EEXIST)
+				msgd(__func__, __LINE__, _("Failed to create `%s\'"), parent);
+		}
+	}
+	else if (!S_ISDIR(st->st_mode)) {
+		msgd(__func__, __LINE__, _("%s\': already exists and not a directory"), parent);
+	}
+
+	g_free(st);
+	g_free(parent);
+}

--- a/rdup-up.h.in
+++ b/rdup-up.h.in
@@ -92,6 +92,8 @@ int mkpath(const char *, mode_t);
 struct stat * dir_write(gchar *);
 void dir_restore(gchar *, struct stat *);
 gchar *dir_parent(gchar *);
+void dir_mkpath(gchar *);
+
 
 /* chown.c */
 void chown_write(gchar *dir, gchar *base, uid_t u, gchar *user, gid_t g, gchar *group);                    


### PR DESCRIPTION
There is an inherent problem with normal dumps: directory a/mtimes don't get reset to the stored value. Reverse dumps suffer no such problem, but rdup-up does not support them as it is.

This is my attempt to support reverse dump in rdup-up, following the logic used when EACCESS is returned. So, in response to an ENOENT error when creating an object, attempt to make the parent path and then try the operation. If this fails log it and move on.

****This relies on dir_parent() not returning the trailing /